### PR TITLE
Added a new unsupported section: 'patents'

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ function LinkedInPdfToJson() {
     };
 
     // currently unsupported sections
-    this.UNSUPPORTED_SECTIONS = ['Publications', 'Projects', 'Certifications', 'Organizations', 'Test Scores', 'Specialties', 'Honors and Awards', 'Interests', 'Courses', 'recommendations'];
+    this.UNSUPPORTED_SECTIONS = ['Publications', 'Projects', 'Certifications', 'Organizations', 'Test Scores', 'Specialties', 'Honors and Awards', 'Interests', 'Courses', 'recommendations', 'Patents'];
 
     // available token values
     this.TOKENS = {


### PR DESCRIPTION
Ran into an error when a pdf had a 'patents' section. Hence this PR to add it to the unsupported array.